### PR TITLE
update GH action to check if will get the prow config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,11 @@ name: Lint
 on: [ pull_request ]
 
 jobs:
-  golangci:
-    name: lint
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.41.1
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.41.1


### PR DESCRIPTION
 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**

/kind other

**What this PR does / why we need it**:
We applied the prow config to make the GH Action - lint a required check before merging (https://github.com/kubernetes/test-infra/pull/22630) but looks like the setting was not applied in the repository.

checking other projects like kOps I saw the config of the GH Action is a bit different from the one we setup here, so adjusting to make it similar

for reference: 
- https://github.com/kubernetes/kops/blob/master/.github/workflows/main.yml (GH Actions)
- https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml#L259-L265 (prow config)

/assign @dims

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
